### PR TITLE
SEV-SNP: Add support for lower privilege levels

### DIFF
--- a/idscp2-ra-snp/snp-attestd/amd_kdc.go
+++ b/idscp2-ra-snp/snp-attestd/amd_kdc.go
@@ -46,7 +46,7 @@ const (
 	bootLoaderOID = "1.3.6.1.4.1.3704.1.3.1"
 	hwidOID       = "1.3.6.1.4.1.3704.1.4"
 
-	// Maximum number of tries when retreiving VCEK certificates from AMD
+	// Maximum number of tries when retrieving VCEK certificates from AMD
 	// Needed as the KDC only allows one request per IP every 10 seconds
 	// With this value, snp-attestd will try to get certificates for one minute before aborting
 	maxTries = 6
@@ -75,7 +75,7 @@ func FetchVcekCertForReport(report ar.AttestationReport) ([]byte, error) {
 		case 200:
 			// Success: do nothing
 		case 429:
-			// Too manny requests: Sleep for 10 seconds and try again
+			// Too many requests: Sleep for 10 seconds and try again
 			time.Sleep(time.Second * 10)
 			continue
 		default:

--- a/idscp2-ra-snp/snp-attestd/attestation_report/attestation_report.go
+++ b/idscp2-ra-snp/snp-attestd/attestation_report/attestation_report.go
@@ -78,7 +78,7 @@ type AttestationReport struct {
 	Reserved4  [368]byte
 }
 
-const ReportSize = 0xA0
+const ReportSize = 0x4a0
 
 // Since the report contains bit fields we need to deserialize manually as Go does not handle them well
 func Deserialize(rawReport []byte) (AttestationReport, error) {

--- a/idscp2-ra-snp/snp-attestd/config.go
+++ b/idscp2-ra-snp/snp-attestd/config.go
@@ -28,6 +28,6 @@ type Config struct {
 	// This directory currently also contains the VCEK certificate chain.
 	CacheDir string
 	// Only accept verify requests.
-	// This is usefull when the SNP guest device is not available.
+	// This is useful when the SNP guest device is not available.
 	VerifyOnly bool
 }

--- a/idscp2-ra-snp/snp-attestd/service_impl.go
+++ b/idscp2-ra-snp/snp-attestd/service_impl.go
@@ -211,7 +211,7 @@ func (s *AttestdServiceImpl) GetReport(ctx context.Context, reportRequest *pb.Re
 		log.Debug("Got a report request with report data %s", hex.EncodeToString(reportRequest.ReportData))
 	}
 
-	report, err := s.dev.GetReport(reportRequest.ReportData)
+	report, raw, err := s.dev.GetReport(reportRequest.ReportData)
 	if err != nil {
 		log.Err("Error retreiving report from the SEV firmware: %v", err)
 		return nil, errServer
@@ -226,14 +226,8 @@ func (s *AttestdServiceImpl) GetReport(ctx context.Context, reportRequest *pb.Re
 		}
 	}
 
-	reportBuffer := new(bytes.Buffer)
-	if err := binary.Write(reportBuffer, binary.LittleEndian, &report); err != nil {
-		log.Err("Could not encode attestation report: %v", err)
-		return nil, errServer
-	}
-
 	response := pb.ReportResponse{
-		Report:   reportBuffer.Bytes(),
+		Report:   raw,
 		VcekCert: vcekCert,
 	}
 

--- a/idscp2-ra-snp/snp-attestd/service_impl.go
+++ b/idscp2-ra-snp/snp-attestd/service_impl.go
@@ -250,6 +250,12 @@ func (s *AttestdServiceImpl) VerifyReport(ctx context.Context, verifyRequest *pb
 		return nil, fmt.Errorf("could not deserialize the attestation report: %e", err)
 	}
 
+	// SigningKey = 0 means the report is signed by the VCEK
+	if report.SigningKey != 0 {
+		log.Debug("Received a report signed with an unsupported key")
+		return nil, fmt.Errorf("only reports signed by a VCEK are supported at this time")
+	}
+
 	ask, ark, err := s.loadCertChain()
 	if err != nil {
 		log.Err("Could not load the VCEK certificate chain: %v", err)

--- a/idscp2-ra-snp/snp-attestd/service_impl.go
+++ b/idscp2-ra-snp/snp-attestd/service_impl.go
@@ -20,7 +20,6 @@
 package snp_attestd
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha1"
 	"crypto/x509"
@@ -245,9 +244,11 @@ func (s *AttestdServiceImpl) VerifyReport(ctx context.Context, verifyRequest *pb
 		log.Trace("Policy: %s", verifyRequest.Policies)
 	}
 
-	var report ar.AttestationReport
-	reportBuf := bytes.NewReader(verifyRequest.Report)
-	binary.Read(reportBuf, binary.LittleEndian, &report)
+	report, err := ar.Deserialize(verifyRequest.Report)
+	if err != nil {
+		log.Debug("Received a report that could not be parsed")
+		return nil, fmt.Errorf("could not deserialize the attestation report: %e", err)
+	}
 
 	ask, ark, err := s.loadCertChain()
 	if err != nil {

--- a/idscp2-ra-snp/snp-attestd/snp_dev.go
+++ b/idscp2-ra-snp/snp-attestd/snp_dev.go
@@ -131,7 +131,7 @@ func (dev *SnpDevice) GetReport(reportData []byte) (parsed ar.AttestationReport,
 	copy(req.userData[:], reportData)
 
 	localVMPL := dev.suspectedVMPL
-	// Try this multiple times with decreasing priviledges until the call works
+	// Try this multiple times with decreasing privileges until the call works
 	for localVMPL < 4 {
 		req.vmpl = localVMPL
 		copy(memory[guestRequestIoctlSize:], unsafe.Slice((*byte)(unsafe.Pointer(&req)), reportReqSize))
@@ -162,7 +162,7 @@ func (dev *SnpDevice) GetReport(reportData []byte) (parsed ar.AttestationReport,
 		case 0:
 			// Success
 		case 0x16:
-			// Invalid paramter -> Includes incorrect VMPL
+			// Invalid parameter -> Includes incorrect VMPL
 			logger.Warn("Could not obtain report at VMPL %d: status code 0x%x", localVMPL, resp.Status)
 			localVMPL++
 			continue

--- a/idscp2-ra-snp/snp-attestd/snp_dev.go
+++ b/idscp2-ra-snp/snp-attestd/snp_dev.go
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +27,7 @@ import (
 	"unsafe"
 
 	ar "github.com/industrial-data-space/idscp2-rat-drivers/idscp2-ra-snp/snp-attestd/attestation_report"
+	"github.com/industrial-data-space/idscp2-rat-drivers/idscp2-ra-snp/snp-attestd/logger"
 
 	"golang.org/x/sys/unix"
 )
@@ -35,6 +36,8 @@ import (
 // Guest ioctls can be executed using methods on this type.
 type SnpDevice struct {
 	file *os.File
+	// Since there does not seem to be way to determine the VMPL we have to guess
+	suspectedVMPL uint32
 }
 
 // Opens the SEV-SNP guest device at the specified path.
@@ -45,7 +48,10 @@ func OpenSnpDevice(path string) (*SnpDevice, error) {
 		return nil, fmt.Errorf("failed to open SEV device: %w", err)
 	}
 
-	return &SnpDevice{file}, nil
+	return &SnpDevice{
+		file:          file,
+		suspectedVMPL: 0,
+	}, nil
 }
 
 type guestRequestIoctl struct {
@@ -81,9 +87,10 @@ const reportRespSize = unsafe.Sizeof(reportResp{})
 // #include <stdio.h>
 // #include <linux/ioctl.h>
 // #include <linux/sev-guest.h>
-// int main() {
-//     printf("%x\n", SNP_GET_REPORT);
-// }
+//
+//	int main() {
+//	    printf("%x\n", SNP_GET_REPORT);
+//	}
 const snpGetReportIoctl = 0xc0205300
 
 // Obtain an attestation report from the SEV firmware containing the specified reportData.
@@ -123,31 +130,51 @@ func (dev *SnpDevice) GetReport(reportData []byte) (ar.AttestationReport, error)
 	req := reportReq{}
 	copy(req.userData[:], reportData)
 
-	copy(memory[guestRequestIoctlSize:], unsafe.Slice((*byte)(unsafe.Pointer(&req)), reportReqSize))
+	localVMPL := dev.suspectedVMPL
+	// Try this multiple times with decreasing priviledges until the call works
+	for localVMPL < 4 {
+		req.vmpl = localVMPL
+		copy(memory[guestRequestIoctlSize:], unsafe.Slice((*byte)(unsafe.Pointer(&req)), reportReqSize))
 
-	// Pass the address of our memory object to the ioctl
-	if err := unix.IoctlSetInt(int(dev.file.Fd()), snpGetReportIoctl, int(memoryAddress)); err != nil {
-		return ar.AttestationReport{}, fmt.Errorf("error issuing ioctl on snp device: %w", err)
+		// Pass the address of our memory object to the ioctl
+		if err := unix.IoctlSetInt(int(dev.file.Fd()), snpGetReportIoctl, int(memoryAddress)); err != nil {
+			return ar.AttestationReport{}, fmt.Errorf("error issuing ioctl on snp device: %w", err)
+		}
+
+		// Copy back the ioctl structure as the firmware response code is now set.
+		// Note: fwError checking is currently disabled as the firmware seems to set this to an invalid value.
+		//copy(unsafe.Slice((*byte)(unsafe.Pointer(&ioctl)), guestRequestIoctlSize), memory)
+		//if ioctl.fwError != 0 {
+		//	return AttestationReport{}, fmt.Errorf("The SEV firmware returned a non-zero error code: %x", ioctl.fwError)
+		//}
+
+		// Copy the response over from the memory buffer.
+		// Since the response comes straight from the firmware, it is packed data.
+		// The data fits in memory, as the packed data is at maximum the same size as reportResp.
+		var resp reportResp
+		if err := binary.Read(bytes.NewReader(memory[guestRequestIoctlSize+reportReqSize:]), binary.LittleEndian, &resp); err != nil {
+			return ar.AttestationReport{}, fmt.Errorf("could not decode the attestation report from the firmware response: %w", err)
+		}
+
+		switch resp.Status {
+		case 0:
+			// Success
+		case 0x16:
+			// Invalid paramter -> Includes incorrect VMPL
+			logger.Warn("Could not obtain report at VMPL %d: status code 0x%x", localVMPL, resp.Status)
+			localVMPL++
+			continue
+		default:
+			// Other errors
+			return ar.AttestationReport{}, fmt.Errorf("the attestation response contains a non-zero status code: %x", resp.Status)
+		}
+
+		if dev.suspectedVMPL != localVMPL {
+			logger.Debug("Setting suspected VMPL to %d", localVMPL)
+			dev.suspectedVMPL = localVMPL
+		}
+		return resp.Report, nil
 	}
 
-	// Copy back the ioctl structure as the firmware response code is now set.
-	// Note: fwError checking is currently disabled as the firmware seems to set this to an invalid value.
-	//copy(unsafe.Slice((*byte)(unsafe.Pointer(&ioctl)), guestRequestIoctlSize), memory)
-	//if ioctl.fwError != 0 {
-	//	return AttestationReport{}, fmt.Errorf("The SEV firmware returned a non-zero error code: %x", ioctl.fwError)
-	//}
-
-	// Copy the response over from the memory buffer.
-	// Since the response comes straight from the firmware, it is packed data.
-	// The data fits in memory, as the packed data is at maximum the same size as reportResp.
-	var resp reportResp
-	if err := binary.Read(bytes.NewReader(memory[guestRequestIoctlSize+reportReqSize:]), binary.LittleEndian, &resp); err != nil {
-		return ar.AttestationReport{}, fmt.Errorf("could not decode the attestation report from the firmware response: %w", err)
-	}
-
-	if resp.Status != 0 {
-		return ar.AttestationReport{}, fmt.Errorf("the attestation response contains a non-zero status code: %x", resp.Status)
-	}
-
-	return resp.Report, nil
+	return ar.AttestationReport{}, fmt.Errorf("could not fetch a report at any VMPL")
 }


### PR DESCRIPTION
The current implementation of the SEV-SNP driver assumes that the virtual machine is always running at the highest privilege level (VMPL 0). With this patch, the driver is able to fetch reports for all four available privilege levels. Notably, this will allow the driver to work properly if a [SVSM](https://github.com/AMDESE/linux-svsm) or similar module is used.

As the SEV guest kernel module does not seem to export the VM's privilege level to userspace at this time, this implementation will try all levels until one works. The pull request also updates the SNP attestation report representation to revision 1.54 of the [SEV-SNP Specification](https://www.amd.com/system/files/TechDocs/56860.pdf).